### PR TITLE
Add clear cell optimization, make instruction list order more logical

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -72,12 +72,10 @@ http://www.hevanet.com/cristofd/brainfuck/]
       .collect::<Vec<char>>();
 
     fn program_to_chars(program: &[Instruction]) -> Vec<char> {
-      program
-        .iter()
-        .fold(Vec::new(), |mut result, instruction| {
-          result.extend(instruction.to_string().chars());
-          result
-        })
+      program.iter().fold(Vec::new(), |mut result, instruction| {
+        result.extend(instruction.to_string().chars());
+        result
+      })
     }
 
     let parsed_program = parse(&source_code_chars).unwrap();

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -4,10 +4,11 @@ use std::fmt;
 pub enum Instruction {
   Move(isize),
   Add(isize),
-  Print,
-  Read,
   JumpIfZero(usize),
   JumpIfNonZero(usize),
+  Print,
+  Read,
+  Clear,
 }
 
 impl fmt::Display for Instruction {
@@ -24,11 +25,13 @@ impl fmt::Display for Instruction {
         Add(n) if *n > 0 => "+".repeat(*n as usize),
         Add(n) if *n < 0 => "-".repeat(n.abs() as usize),
 
+        JumpIfZero(_) => "[".to_owned(),
+        JumpIfNonZero(_) => "]".to_owned(),
+
         Print => ".".to_owned(),
         Read => ",".to_owned(),
 
-        JumpIfZero(_) => "[".to_owned(),
-        JumpIfNonZero(_) => "]".to_owned(),
+        Clear => "[-]".to_owned(),
 
         _ => String::default(),
       }
@@ -70,7 +73,7 @@ http://www.hevanet.com/cristofd/brainfuck/]
 
     fn program_to_chars(program: &[Instruction]) -> Vec<char> {
       program
-        .into_iter()
+        .iter()
         .fold(Vec::new(), |mut result, instruction| {
           result.extend(instruction.to_string().chars());
           result

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -59,15 +59,17 @@ impl Interpreter {
           });
         }
 
-        Print => self.print_char(output)?,
-        Read => self.read_char(input)?,
-
         JumpIfZero(address) => if self.read_memory() == 0 {
           char_index = address;
         },
         JumpIfNonZero(address) => if self.read_memory() != 0 {
           char_index = address;
         },
+
+        Print => self.print_char(output)?,
+        Read => self.read_char(input)?,
+
+        Clear => self.store_memory(0),
       }
 
       char_index += 1;

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -32,21 +32,23 @@ impl Interpreter {
 
     while char_index < program.len() {
       match program[char_index] {
-        Move(n) => if n > 0 {
-          let n = n as usize;
-          if n <= self.memory.len() && self.pointer < self.memory.len() - n {
-            self.pointer += n;
-          } else {
-            return Err(Error::PointerOverflow);
+        Move(n) => {
+          if n > 0 {
+            let n = n as usize;
+            if n <= self.memory.len() && self.pointer < self.memory.len() - n {
+              self.pointer += n;
+            } else {
+              return Err(Error::PointerOverflow);
+            }
+          } else if n < 0 {
+            let n = n.abs() as usize;
+            if self.pointer >= n {
+              self.pointer -= n;
+            } else {
+              return Err(Error::PointerUnderflow);
+            }
           }
-        } else if n < 0 {
-          let n = n.abs() as usize;
-          if self.pointer >= n {
-            self.pointer -= n;
-          } else {
-            return Err(Error::PointerUnderflow);
-          }
-        },
+        }
 
         Add(n) => {
           let value = self.read_memory();
@@ -59,12 +61,16 @@ impl Interpreter {
           });
         }
 
-        JumpIfZero(address) => if self.read_memory() == 0 {
-          char_index = address;
-        },
-        JumpIfNonZero(address) => if self.read_memory() != 0 {
-          char_index = address;
-        },
+        JumpIfZero(address) => {
+          if self.read_memory() == 0 {
+            char_index = address;
+          }
+        }
+        JumpIfNonZero(address) => {
+          if self.read_memory() != 0 {
+            char_index = address;
+          }
+        }
 
         Print => self.print_char(output)?,
         Read => self.read_char(input)?,

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -48,17 +48,17 @@ pub fn optimize(program: &[Instruction]) -> Result<Vec<Instruction>> {
         Move(total)
       }
 
-    JumpIfZero(loop_end) => {
-        match &program[index + 1 ..= loop_end] {
-            // Optimizes clear loops into Clear instruction
-            [Add(-1), JumpIfNonZero(_)] => {
-                skip_chars += 2;
-                Clear
-            },
+      JumpIfZero(loop_end) => {
+        match program.get(index + 1..=loop_end) {
+          // Optimizes clear loops into Clear instruction
+          Some([Add(-1), JumpIfNonZero(_)]) => {
+            skip_chars += 2;
+            Clear
+          }
 
-            _ => instruction,
+          _ => instruction,
         }
-    },
+      }
 
       _ => instruction,
     });
@@ -143,14 +143,9 @@ mod tests {
   );
 
   test!(
-      test_clear_pattern,
-      [
-      Add(1),
-      JumpIfZero(0),
-      Add(-1),
-      JumpIfNonZero(0),
-      ],
-      [Add(1), Clear]
+    test_clear_pattern,
+    [Add(5), JumpIfZero(3), Add(-1), JumpIfNonZero(1), Print],
+    [Add(5), Clear, Print]
   );
 
   test!(

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -48,6 +48,16 @@ pub fn optimize(program: &[Instruction]) -> Result<Vec<Instruction>> {
         Move(total)
       }
 
+    JumpIfZero(_) => {
+        match program[index + 1 .. program.len()] {
+            [Add(-1), JumpIfNonZero(_)] => {
+                skip_chars += 2;
+                Clear
+            },
+            _ => instruction,
+        }
+    },
+
       _ => instruction,
     });
   }
@@ -128,6 +138,17 @@ mod tests {
       Move(-1),
     ],
     [Add(-1), Move(1)]
+  );
+
+  test!(
+      test_clear_pattern,
+      [
+      Add(1),
+      JumpIfZero(0),
+      Add(-1),
+      JumpIfNonZero(0),
+      ],
+      [Add(1), Clear]
   );
 
   test!(

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -51,7 +51,7 @@ pub fn optimize(program: &[Instruction]) -> Result<Vec<Instruction>> {
       JumpIfZero(loop_end) => {
         match program.get(index + 1..=loop_end) {
           // Optimizes clear loops into Clear instruction
-          Some([Add(-1), JumpIfNonZero(_)]) => {
+          Some([Add(_), JumpIfNonZero(_)]) => {
             skip_chars += 2;
             Clear
           }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -49,7 +49,7 @@ pub fn optimize(program: &[Instruction]) -> Result<Vec<Instruction>> {
       }
 
     JumpIfZero(_) => {
-        match program[index + 1 .. program.len()] {
+        match &program[index + 1 ..] {
             [Add(-1), JumpIfNonZero(_)] => {
                 skip_chars += 2;
                 Clear

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -48,12 +48,14 @@ pub fn optimize(program: &[Instruction]) -> Result<Vec<Instruction>> {
         Move(total)
       }
 
-    JumpIfZero(_) => {
-        match &program[index + 1 ..] {
+    JumpIfZero(loop_end) => {
+        match &program[index + 1 ..= loop_end] {
+            // Optimizes clear loops into Clear instruction
             [Add(-1), JumpIfNonZero(_)] => {
                 skip_chars += 2;
                 Clear
             },
+
             _ => instruction,
         }
     },


### PR DESCRIPTION
A common programming pattern in BF is to use `[-]` to reset the current memory cell to 0, this commit adds a `Clear` instruction which will replace detected instances of this pattern with an instruction that essentially ignores the loop and immediately sets the current cell to 0. This can impact performance greatly for some programs.

This commit also changes the order of the instruction list to put all instructions that do not contain values at the bottom, making the list slightly more readable and organized.